### PR TITLE
feat: windows support

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,13 +3,14 @@ import { constants } from 'fs';
 import path from 'path';
 
 export const workingDir = () => process.cwd();
+const rootDir = path.parse(process.cwd()).root;
 
 const findTopLevelDir = async (dir: string): Promise<string> => {
   try {
     await fs.access(path.join(dir, '.adr-dir'), constants.F_OK);
     return dir;
   } catch (e) {
-    if (dir === '/') {
+    if (dir === rootDir) {
       throw new Error('No ADR directory config found');
     }
     const newDir = path.join(dir, '..');


### PR DESCRIPTION
Since the root dir looks different in Windows and Unix (`C:\\` vs `/`), use crossplatform way of getting it

Closes: #251