### PR TITLE
Add explicit sort when generating toc

### DIFF
--- a/src/lib/adr.ts
+++ b/src/lib/adr.ts
@@ -130,7 +130,7 @@ export const generateToc = async (options?: {prefix?: string}) => {
 
   const adrDir = await getDir();
   const files = await fs.readdir(adrDir);
-  const toc = files.filter((file) => file.match(/^\d{4}-.*\.md$/));
+  const toc = files.filter((file) => file.match(/^\d{4}-.*\.md$/)).sort();
 
   const titles = toc.map(async (file) => {
     const title = getTitleFrom(await fs.readFile(path.join(adrDir, file), 'utf8'));


### PR DESCRIPTION
Added explicit sorting of adr files upon retrieval.

Fixes #393.