### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   verifypr:
     name: Verify PR
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
   release:
     needs: [build]
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: ${{ github.ref_name == 'main' || github.ref_name == 'next' }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Replace compatible GitHub-hosted runner selections with the self-hosted runner.