### PR TITLE
chore(ci): use meza ubuntu slim runner

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   verifypr:
     name: Verify PR
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build:
 
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
   release:
     needs: [build]
     name: Release
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     if: ${{ github.ref_name == 'main' || github.ref_name == 'next' }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Replace `runs-on: self-hosted` with `runs-on: meza-ubuntu-slim` in 2 GitHub Actions workflow files.

## Validation

- Verified 3 exact runner-label replacements.
- Verified no other staged lines changed.
- `git diff --check` passes.